### PR TITLE
mongo servers aren't supposed to be named hadoop, they're supposed to be named mongo!

### DIFF
--- a/mongodb/hosts
+++ b/mongodb/hosts
@@ -2,28 +2,28 @@
 
 # the mongo servers need a mongod_port variable set, and they must not conflict.
 [mongo_servers]
-hadoop1 mongod_port=2700
-hadoop2 mongod_port=2701
-hadoop3 mongod_port=2702
-hadoop4 mongod_port=2703
+mongo1 mongod_port=2700
+mongo2 mongod_port=2701
+mongo3 mongod_port=2702
+mongo4 mongod_port=2703
 
 #The list of servers where replication should happen, by default include all servers
 [replication_servers]
-hadoop1
-hadoop2
-hadoop3
-hadoop4
+mongo1
+mongo2
+mongo3
+mongo4
 
 #The list of mongodb configuration servers, make sure it is 1 or 3
 [mongoc_servers]
-hadoop1
-hadoop2
-hadoop3
+mongo1
+mongo2
+mongo3
 
 
 #The list of servers where mongos servers would run. 
 [mongos_servers]
-hadoop1
-hadoop2
+mongo1
+mongo2
 
 


### PR DESCRIPTION
It looks like this file was copied from a hadoop example and not all
instances of the word "hadoop" were replaced with "mongo." Running a quick
s/hadoop/mongo/g fixes this up to provide a more clear example.
