### PR TITLE
document use of raw variables in loop_nested

### DIFF
--- a/language_features/loop_nested.yml
+++ b/language_features/loop_nested.yml
@@ -8,3 +8,17 @@
         - [ 'red', 'blue', 'green' ]
         - [ 1, 2, 3 ]
         - [ 'up', 'down', 'strange']
+
+# you can reference a raw variable name without putting it in {{ brackets }}
+
+- hosts: all
+  vars:
+    listvar1:
+    - 'a'
+    - 'b'
+    - 'c'
+  tasks:
+    - shell: echo "nested test a={{ item[0] }} b={{ item[1] }}"
+      with_nested:
+        - listvar1
+        - [ 1, 2, 3 ]


### PR DESCRIPTION
Together with a patch to the playbooks2.rst docs for the ansible repo, this documents the use of raw variables in loop_nested, and closes https://github.com/ansible/ansible/issues/3513.
