### PR TITLE
prevent non-existent file from breaking play

### DIFF
--- a/lamp_simple/roles/web/tasks/install_httpd.yml
+++ b/lamp_simple/roles/web/tasks/install_httpd.yml
@@ -12,7 +12,7 @@
    - libselinux-python
 
 - name: insert iptables rule for httpd
-  lineinfile: dest=/etc/sysconfig/iptables state=present regexp="{{ httpd_port }}" insertafter="^:OUTPUT "
+  lineinfile: dest=/etc/sysconfig/iptables create=yes state=present regexp="{{ httpd_port }}" insertafter="^:OUTPUT "
               line="-A INPUT -p tcp  --dport {{ httpd_port }} -j  ACCEPT"
   notify: restart iptables
 


### PR DESCRIPTION
fixes:
failed: [127.0.0.1] => {"failed": true, "item": "", "rc": 257}
msg: Destination /etc/sysconfig/iptables does not exist !

create=yes allows it to not fail on non-existent file, but because regex={{ httpd_port }} doesn't match anything, nothing is done (no file is created)
