### PR TITLE
Fix README for hadoop:

### DIFF
--- a/hadoop/README.md
+++ b/hadoop/README.md
@@ -332,6 +332,10 @@ The following diagram illustrates a standalone Hadoop cluster.
 
 To deploy this cluster fill in the inventory file as follows: 
 
+		[hadoop_all:children]
+		hadoop_masters
+		hadoop_slaves
+
 		[hadoop_master_primary]
 		zhadoop1
 


### PR DESCRIPTION
If hadoop_all is excluded, then the role common is never executed
