### PR TITLE
Add local hostname to the 127.0.0.1 entry

### DIFF
--- a/hadoop/roles/common/templates/etc/hosts.j2
+++ b/hadoop/roles/common/templates/etc/hosts.j2
@@ -1,4 +1,4 @@
-127.0.0.1 localhost
+127.0.0.1 localhost {{ ansible_hostname }}
 {% for host in groups.all %}
 {{ hostvars[host]['ansible_' + iface].ipv4.address }}  {{ host }}
 {% endfor %}


### PR DESCRIPTION
The default task will replace my /etc/hosts from:

127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4 hadoop-master
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6

to

127.0.0.1 localhost

Breaking some parts of the OS because the hostname of the machine ("hadoop-master" in my case) is not bound to 127.0.0.1 anymore.
