### PR TITLE
complex_args: update example for ansbile-1.7

### DIFF
--- a/language_features/complex_args.yml
+++ b/language_features/complex_args.yml
@@ -40,11 +40,8 @@
 
     - name: can we make that cleaner? sure!
       action: ping
-      args: { data: $complex }
+      args: { data: "{{ complex }}" }
 
     - name: here is an example of how it works with defaults, notice the key=value format wins
       action: service name=httpd state=running
-      args: $defaults
-
-
-
+      args: defaults


### PR DESCRIPTION
`$` is obsolete and fails to work with ansible-playbook 1.7 (devel 6bc056e012)
