### PR TITLE
Fix issue when "SELinux is disabled on this host."

### DIFF
--- a/wordpress-nginx/roles/mysql/tasks/main.yml
+++ b/wordpress-nginx/roles/mysql/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: Configure SELinux to start mysql on any port
   seboolean: name=mysql_connect_any state=true persistent=yes
+  when: ansible_selinux.status == "enabled"
 
 - name: Create Mysql configuration file
   template: src=my.cnf.j2 dest=/etc/my.cnf


### PR DESCRIPTION
If SELinux is already disabled, then skip:

```
"Configure SELinux to start mysql on any port"
```
