### PR TITLE
fix for wrong domain name string in openshift named.conf template 

### DIFF
--- a/openshift/roles/dns/templates/named.conf.j2
+++ b/openshift/roles/dns/templates/named.conf.j2
@@ -37,7 +37,7 @@ include "{{ domain_name }}.key";
 
 controls {   
 	inet * port {{ rndc_port }} allow { any; } 
-	keys { example.com; }; 
+	keys { {{ domain_name }}; }; 
 };
 
 zone "{{ domain_name }}" IN {


### PR DESCRIPTION
I just found that openshift/roles/dns/templates/named.conf.j2 has hardcoded value of domain example.com
