### PR TITLE
Replace the legacy 'action: module options'  format

### DIFF
--- a/language_features/ansible_pull.yml
+++ b/language_features/ansible_pull.yml
@@ -40,17 +40,17 @@
   tasks:
 
     - name: Install ansible
-      action: yum pkg=ansible state=installed
+      yum: pkg=ansible state=installed
 
     - name: Create local directory to work from
-      action: file path={{workdir}} state=directory owner=root group=root mode=0751
+      file: path={{workdir}} state=directory owner=root group=root mode=0751
 
     - name: Copy ansible inventory file to client
-      action: copy src=/etc/ansible/hosts dest=/etc/ansible/hosts
+      copy: src=/etc/ansible/hosts dest=/etc/ansible/hosts
               owner=root group=root mode=0644
 
     - name: Create crontab entry to clone/pull git repository
-      action: template src=templates/etc_cron.d_ansible-pull.j2 dest=/etc/cron.d/ansible-pull owner=root group=root mode=0644
+      template: src=templates/etc_cron.d_ansible-pull.j2 dest=/etc/cron.d/ansible-pull owner=root group=root mode=0644
 
     - name: Create logrotate entry for ansible-pull.log
-      action: template src=templates/etc_logrotate.d_ansible-pull.j2 dest=/etc/logrotate.d/ansible-pull owner=root group=root mode=0644
+      template: src=templates/etc_logrotate.d_ansible-pull.j2 dest=/etc/logrotate.d/ansible-pull owner=root group=root mode=0644

--- a/language_features/batch_size_control.yml
+++ b/language_features/batch_size_control.yml
@@ -12,8 +12,8 @@
   tasks:
 
   - name: ping
-    action: ping
+    ping:
   - name: ping2
-    action: ping
+    ping:
 
 

--- a/language_features/conditionals_part1.yml
+++ b/language_features/conditionals_part1.yml
@@ -43,7 +43,7 @@
     action: "{{ packager }} pkg={{ apache }} state=latest"
 
   - name: ensure apache is running
-    action: service name={{ apache }} state=running
+    service: name={{ apache }} state=running
 
 
 

--- a/language_features/conditionals_part2.yml
+++ b/language_features/conditionals_part2.yml
@@ -14,27 +14,27 @@
   tasks:
 
      - name: "do this if my favcolor is blue, and my dog is named fido"
-       action: shell /bin/false
+       shell: /bin/false
        when: favcolor == 'blue' and dog == 'fido'
 
      - name: "do this if my favcolor is not blue, and my dog is named fido"
-       action: shell /bin/true
+       shell: /bin/true
        when: favcolor != 'blue' and dog == 'fido'
 
      - name: "do this if my SSN is over 9000"
-       action: shell /bin/true
+       shell: /bin/true
        when: ssn > 9000
 
      - name: "do this if I have one of these SSNs"
-       action: shell /bin/true
+       shell: /bin/true
        when:  ssn in [ 8675309, 8675310, 8675311 ]
      
      - name: "do this if a variable named hippo is NOT defined"
-       action: shell /bin/true
+       shell: /bin/true
        when: hippo is not defined
 
      - name: "do this if a variable named hippo is defined"
-       action: shell /bin/true
+       shell: /bin/true
        when: hippo is defined
 
 

--- a/language_features/custom_filters.yml
+++ b/language_features/custom_filters.yml
@@ -3,4 +3,4 @@
 - name: Demonstrate custom jinja2 filters
   hosts: all
   tasks:
-  - action: template src=templates/custom-filters.j2 dest=/tmp/custom-filters.txt
+  - template: src=templates/custom-filters.j2 dest=/tmp/custom-filters.txt

--- a/language_features/delegation.yml
+++ b/language_features/delegation.yml
@@ -22,7 +22,7 @@
   tasks:
   
   - name: take the machine out of rotation
-    action: command echo taking out of rotation {{inventory_hostname}}
+    command: echo taking out of rotation {{inventory_hostname}}
     delegate_to: 127.0.0.1
 
 # here's an alternate notation if you are delegating to 127.0.0.1, you can use 'local_action' 
@@ -31,9 +31,9 @@
 # - local_action: command echo taking out of rotation {{inventory_hostname}}
 
   - name: do several things on the actual host
-    action: command echo hi mom {{inventory_hostname}}
+    command: echo hi mom {{inventory_hostname}}
   
   - name: put machine back into rotation
-    action: command echo inserting into rotation {{inventory_hostname}}
+    command: echo inserting into rotation {{inventory_hostname}}
     delegate_to: 127.0.0.1
 

--- a/language_features/file_secontext.yml
+++ b/language_features/file_secontext.yml
@@ -4,15 +4,15 @@
   user: root
   tasks:
     - name: Change setype of /etc/exports to non-default value
-      action: file path=/etc/exports setype=etc_t
+      file: path=/etc/exports setype=etc_t
     - name: Change seuser of /etc/exports to non-default value
-      action: file path=/etc/exports seuser=unconfined_u
+      file: path=/etc/exports seuser=unconfined_u
     - name: Set selinux context back to default value
-      action: file path=/etc/exports context=default
+      file: path=/etc/exports context=default
     - name: Create empty file
-      action: command /bin/touch /tmp/foo
+      command: /bin/touch /tmp/foo
     - name: Change setype of /tmp/foo
-      action: file path=/tmp/foo setype=default_t
+      file: path=/tmp/foo setype=default_t
     - name: Try to set secontext to default, but this will fail
             because of the lack of a default in the policy
-      action: file path=/tmp/foo context=default
+      file: path=/tmp/foo context=default

--- a/language_features/get_url.yml
+++ b/language_features/get_url.yml
@@ -5,12 +5,12 @@
   - person: 'Susie%20Smith'
   tasks:
   - name: Create directory for jQuery
-    action: file dest={{jquery_directory}} state=directory mode=0755
+    file: dest={{jquery_directory}} state=directory mode=0755
   - name: Grab a bunch of jQuery stuff
-    action: get_url url=http://code.jquery.com/{{item}}  dest={{jquery_directory}} mode=0444
+    get_url: url=http://code.jquery.com/{{item}}  dest={{jquery_directory}} mode=0444
     with_items:
     - jquery.min.js
     - mobile/latest/jquery.mobile.min.js
     - ui/jquery-ui-git.css
   #- name: Pass urlencoded name to CGI
-  #  action: get_url url=http://example.com/name.cgi?name='{{person}}' dest=/tmp/test
+  #  get_url: url=http://example.com/name.cgi?name='{{person}}' dest=/tmp/test

--- a/language_features/group_by.yml
+++ b/language_features/group_by.yml
@@ -13,7 +13,7 @@
   tasks:
 
   - name: Create a group of all hosts by operating system
-    action: group_by key={{ansible_distribution}}-{{ansible_distribution_version}}
+    group_by: key={{ansible_distribution}}-{{ansible_distribution_version}}
 
 # the following host group does not exist in inventory and was created by the group_by
 # module.
@@ -23,13 +23,13 @@
   tasks:
 
   - name: ping all CentOS 6.2 hosts
-    action: ping
+    ping:
 
 - hosts: CentOS-6.3
 
   tasks:
   
   - name: ping all CentOS 6.3 hosts
-    action: ping
+    ping:
 
 

--- a/language_features/group_commands.yml
+++ b/language_features/group_commands.yml
@@ -9,10 +9,10 @@
 
     # Walk through group creation, modification, and deletion
     - name: create a group
-      action: group name=tset
+      group: name=tset
 
     # You can only modify the group's gid
-    - action: group name=tset gid=7777
+    - group: name=tset gid=7777
 
     # And finally remove the group
-    - action: group name=tset state=absent
+    - group: name=tset state=absent

--- a/language_features/handlers/handlers.yml
+++ b/language_features/handlers/handlers.yml
@@ -5,6 +5,6 @@
 # just like normal handlers.
 
 - name: restart apache
-  action: service name=httpd state=restarted
+  service: name=httpd state=restarted
 - name: restart memcached
-  action: service name=memcached state=restarted
+  service: name=memcached state=restarted

--- a/language_features/intermediate_example.yml
+++ b/language_features/intermediate_example.yml
@@ -25,7 +25,7 @@
   # tasks can be written the normal way...
 
   - name: arbitrary command
-    action: command /bin/true
+    command: /bin/true
 
   # or we can promote reuse and simplicity by including tasks
   # from other files, for instance, to reuse common tasks
@@ -53,7 +53,7 @@
     # handlers that have been notified get executed
 
     - name: restart foo
-      action: service name=foo state=restarted
+      service: name=foo state=restarted
 
 # ===============================================================
 
@@ -86,6 +86,6 @@
   tasks:
 
      - name: some random command
-       action: command /bin/true
+       command: /bin/true
 
 

--- a/language_features/intro_example.yml
+++ b/language_features/intro_example.yml
@@ -31,7 +31,7 @@
   # obviously this does nothing useful but you get the idea
 
   - name: longrunner
-    action: command /bin/sleep 15
+    command: /bin/sleep 15
     async: 45
     poll: 5
 
@@ -47,19 +47,19 @@
   # end of the playbook run
 
   - name: write some_random_foo configuration
-    action: template src=templates/foo.j2 dest=/etc/some_random_foo.conf
+    template: src=templates/foo.j2 dest=/etc/some_random_foo.conf
     notify:
     - restart apache
 
   # make sure httpd is installed at the latest version
 
   - name: install httpd
-    action: yum pkg=httpd state=latest
+    yum: pkg=httpd state=latest
 
   # make sure httpd is running
 
   - name: httpd start
-    action: service name=httpd state=running
+    service: name=httpd state=running
 
   # handlers are only run when things change, at the very end of each
   # play.  Let's define some.  The names are significant and must
@@ -71,6 +71,6 @@
     # is changed, and only then
 
     - name: restart apache
-      action: service name=httpd state=restarted
+      service: name=httpd state=restarted
 
 

--- a/language_features/loop_with_items.yml
+++ b/language_features/loop_with_items.yml
@@ -9,19 +9,19 @@
   tasks:
 
   - name: install packages
-    action: yum name={{ item }} state=installed
+    yum: name={{ item }} state=installed
     with_items:
        - cobbler
        - httpd
 
   - name: configure users
-    action: user name={{ item }} state=present groups=wheel
+    user: name={{ item }} state=present groups=wheel
     with_items:
        - testuser1
        - testuser2
 
   - name: remove users
-    action: user name={{ item }} state=absent
+    user: name={{ item }} state=absent
     with_items:
         - testuser1
         - testuser2

--- a/language_features/mysql.yml
+++ b/language_features/mysql.yml
@@ -9,10 +9,10 @@
   tasks:
 
     - name: Create database user
-      action: mysql_user user=bob password=12345 priv=*.*:ALL state=present
+      mysql_user: user=bob password=12345 priv=*.*:ALL state=present
 
     - name: Create database
-      action: mysql_db db=bobdata state=present
+      mysql_db: db=bobdata state=present
 
     - name: Ensure no user named 'sally' exists and delete if found.
-      action: mysql_user user=sally state=absent
+      mysql_user: user=sally state=absent

--- a/language_features/nested_playbooks.yml
+++ b/language_features/nested_playbooks.yml
@@ -14,7 +14,7 @@
   tasks:
   - name: say hi
     tags: foo
-    action: shell echo "hi..."
+    shell: echo "hi..."
 
 # and this is how we include another playbook, be careful and
 # don't recurse infinitely or anything.  Note you can't use

--- a/language_features/netscaler.yml
+++ b/language_features/netscaler.yml
@@ -16,10 +16,10 @@
 
   tasks:
     - name: disable service in the lb
-      action: netscaler nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=disable
+      netscaler: nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=disable
 
     - name: deploy new code
-      action: shell yum upgrade -y
+      shell: yum upgrade -y
 
     - name: enable in the lb
-      action: netscaler nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=enable
+      netscaler: nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=enable

--- a/language_features/netscaler.yml
+++ b/language_features/netscaler.yml
@@ -6,20 +6,20 @@
 - hosts: web-pool
   serial: 3
   vars:
-  	nsc_host: nsc.example.com
-  	nsc_user: admin
-  	nsc_pass: nimda
-  	# type of the netscaler object you want to manipulate
-  	type: service
-  	# netscaler object name
-  	name: "{{facter_fqdn}}:8080"
+    nsc_host: nsc.example.com
+    nsc_user: admin
+    nsc_pass: nimda
+    # type of the netscaler object you want to manipulate
+    type: service
+    # netscaler object name
+    name: "{{facter_fqdn}}:8080"
 
   tasks:
-  	- name: disable service in the lb
-  	  action: netscaler nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=disable
+    - name: disable service in the lb
+      action: netscaler nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=disable
 
-  	- name: deploy new code
-  	  action: shell yum upgrade -y
+    - name: deploy new code
+      action: shell yum upgrade -y
 
-  	- name: enable in the lb
-  	  action: netscaler nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=enable
+    - name: enable in the lb
+      action: netscaler nsc_host={{nsc_host}} user={{nsc_user}} password={{nsc_pass}} name={{name}} type={{type}} action=enable

--- a/language_features/postgresql.yml
+++ b/language_features/postgresql.yml
@@ -12,9 +12,9 @@
 
   tasks:
   - name: ensure apt cache is up to date
-    action: apt update_cache=yes
+    apt: update_cache=yes
   - name: ensure packages are installed
-    action: apt name={{item}}
+    apt: name={{item}}
     with_items:
         - postgresql
         - libpq-dev

--- a/language_features/prompts.yml
+++ b/language_features/prompts.yml
@@ -50,10 +50,10 @@
   tasks:
 
   - name: imagine this did something interesting with {{release_version}}
-    action: shell echo foo >> /tmp/{{release_version}}-alpha
+    shell: echo foo >> /tmp/{{release_version}}-alpha
 
   - name: look we crypted a password
-    action: shell echo my password is {{my_password2}}
+    shell: echo my password is {{my_password2}}
 
 
 

--- a/language_features/register_logic.yml
+++ b/language_features/register_logic.yml
@@ -12,7 +12,7 @@
       # it is possible to save the result of any command in a named register.  This variable will be made
       # available to tasks and templates made further down in the execution flow.  
 
-      - action: shell grep hi /etc/motd
+      - shell: grep hi /etc/motd
         ignore_errors: yes
         register: motd_result
 
@@ -22,12 +22,12 @@
 
       # here we run the next action only if the previous grep returned true
 
-      - action: shell echo "motd contains the word hi"
+      - shell: echo "motd contains the word hi"
         when: motd_result.rc == 0
 
       # alternatively:
 
-      - action: shell echo "motd contains the word hi"
+      - shell: echo "motd contains the word hi"
         when: motd_result.stdout.find('hi') != -1
 
 

--- a/language_features/selective_file_sources.yml
+++ b/language_features/selective_file_sources.yml
@@ -9,7 +9,7 @@
   tasks:
 
   - name: template a config file
-    action: template dest=/etc/imaginary_file.conf
+    template: dest=/etc/imaginary_file.conf
     first_available_file:
 
        # first see if we have a file for this specific host

--- a/language_features/tags.yml
+++ b/language_features/tags.yml
@@ -29,7 +29,7 @@
 
   - name: hi
     tags: foo
-    action: shell echo "first task ran"
+    shell: echo "first task ran"
 
 - name: example play two
   hosts: all
@@ -38,7 +38,7 @@
   - name: hi
     tags:
        - bar
-    action: shell echo "second task ran"
+    shell: echo "second task ran"
   - include: tasks/base.yml tags=base
 
 

--- a/language_features/tasks/base.yml
+++ b/language_features/tasks/base.yml
@@ -12,10 +12,10 @@
 # (like this) that might be applied to all your systems as well.
 
 - name: no selinux
-  action: command /usr/sbin/setenforce 0
+  command: /usr/sbin/setenforce 0
 
 - name: no iptables
-  action: service name=iptables state=stopped
+  service: name=iptables state=stopped
 
 - name: made up task just to show variables work here
-  action: command /bin/echo release is $release
+  command: /bin/echo release is $release

--- a/language_features/user_commands.yml
+++ b/language_features/user_commands.yml
@@ -13,26 +13,26 @@
 
     # Walk through account creation, modification, and deletion
     - name: test basic user account creation
-      action: user name=tset comment=TsetUser group=users shell=/sbin/nologin createhome=no
+      user: name=tset comment=TsetUser group=users shell=/sbin/nologin createhome=no
 
     # the following is just a simple example of how you don't have to include
     # the 'name' element for each task
 
-    - action: user name=tset comment=NyetUser
-    - action: user name=tset password={{password}}
+    - user: name=tset comment=NyetUser
+    - user: name=tset password={{password}}
 
     # The following will add the user to supplementary groups.
 
     # Add the user to the groups dialout and uucp.
-    - action: user name=tset groups=dialout,uucp
+    - user: name=tset groups=dialout,uucp
 
     # Add the user to the groups dialout and wheel,
     # This will remove tset from the group uucp.
-    - action: user name=tset groups=dialout,wheel
+    - user: name=tset groups=dialout,wheel
 
     # Add the user to the group uucp.  Because append=yes, the user
     # will not be removed from the groups dialout and wheel.
-    - action: user name=tset groups=uucp append=yes
+    - user: name=tset groups=uucp append=yes
 
     # Finally, remove the user.
-    - action: user name=tset state=absent
+    - user: name=tset state=absent

--- a/language_features/zfs.yml
+++ b/language_features/zfs.yml
@@ -13,21 +13,21 @@
   tasks:
 
   - name: Create a zfs file system
-    action: zfs name={{pool}}/var/log/httpd state=present 
+    zfs: name={{pool}}/var/log/httpd state=present
 
   - name: Create a zfs file system with quota of 10GiB and visible snapdir
-    action: zfs name={{pool}}/ansible quota='10G' snapdir=visible state=present
+    zfs: name={{pool}}/ansible quota='10G' snapdir=visible state=present
 
   - name: Crate zfs snapshot of the above file system
-    action: zfs name={{pool}}/ansible@mysnapshot state=present 
+    zfs: name={{pool}}/ansible@mysnapshot state=present
 
   - name: Create zfs volume named smallvol with a size of 10MiB
-    action: zfs name={{pool}}/smallvol volsize=10M state=present
+    zfs: name={{pool}}/smallvol volsize=10M state=present
 
   - name: Removes snapshot of rpool/oldfs
-    action: zfs name={{pool}}/oldfs@oldsnapshot state=absent
+    zfs: name={{pool}}/oldfs@oldsnapshot state=absent
 
   - name: Removes file system rpool/oldfs
-    action: zfs name={{pool}}/oldfs state=absent
+    zfs: name={{pool}}/oldfs state=absent
 
 


### PR DESCRIPTION
As the documentation recommends to replace the legacy 'action: module options'  format with the “module: options” format, it seems better to use this recommended format in the examples as well.