### PR TITLE
Installing EPEL correctly for Centos/RHEL 6 and 7

### DIFF
--- a/tomcat-standalone/roles/selinux/tasks/main.yml
+++ b/tomcat-standalone/roles/selinux/tasks/main.yml
@@ -1,9 +1,21 @@
 ---
-- name: Download EPEL Repo
+# Download and install EPEL for Centos/RHEL version 6
+- name: Download EPEL Repo - Centos/RHEL 6
   get_url: url=http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm dest=/tmp/epel-release-6-8.noarch.rpm
+  when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '6'"
 
-- name: Install EPEL Repo
+- name: Install EPEL Repo - Centos/RHEL 6
   command: rpm -ivh /tmp/epel-release-6-8.noarch.rpm creates=/etc/yum.repos.d/epel.repo
+  when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '6'"
+
+# Download and install EPEL for Centos/RHEL version 7
+- name: Download EPEL Repo - Centos/RHEL 7
+  get_url: url=http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm dest=/tmp/epel-release-7-5.noarch.rpm
+  when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
+
+- name: Install EPEL Repo - Centos/RHEL 7
+  command: rpm -ivh /tmp/epel-release-7-5.noarch.rpm creates=/etc/yum.repos.d/epel.repo
+  when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
 
 - name: Install libselinux-python
   yum: name=libselinux-python


### PR DESCRIPTION
Right now the playbook installs EPEL 6.8, which is correct on Centos 6. I added conditions (when) to decide which EPEL version to install depending on the distribution version: RedHat family AND distrib 6 or 7

Look at http://www.tecmint.com/how-to-enable-epel-repository-for-rhel-centos-6-5/ for more info.