### PR TITLE
Update HAProxy rolling_update.yml example - use haproxy module.

### DIFF
--- a/lamp_haproxy/rolling_update.yml
+++ b/lamp_haproxy/rolling_update.yml
@@ -18,12 +18,12 @@
   # These are the tasks to run before applying updates:
   pre_tasks:
   - name: disable nagios alerts for this host webserver service
-    nagios: action=disable_alerts host={{ inventory_hostname }} services=webserver
+    nagios: 'action=disable_alerts host={{ inventory_hostname }} services=webserver'
     delegate_to: "{{ item }}"
     with_items: groups.monitoring
 
   - name: disable the server in haproxy
-    shell: echo "disable server myapplb/{{ inventory_hostname }}" | socat stdio /var/lib/haproxy/stats
+    haproxy: 'state=disabled backend=myapplb host={{ inventory_hostname }} socket=/var/lib/haproxy/stats'
     delegate_to: "{{ item }}"
     with_items: groups.lbservers
 
@@ -34,15 +34,15 @@
 
   # These tasks run after the roles:
   post_tasks:
-  - name: Wait for webserver to come up
-    wait_for: host={{ inventory_hostname }} port=80 state=started timeout=80
+  - name: wait for webserver to come up
+    wait_for: 'host={{ inventory_hostname }} port=80 state=started timeout=80'
 
-  - name: Enable the server in haproxy
-    shell: echo "enable server myapplb/{{ inventory_hostname }}" | socat stdio /var/lib/haproxy/stats
+  - name: enable the server in haproxy
+    haproxy: 'state=enabled backend=myapplb host={{ inventory_hostname }} socket=/var/lib/haproxy/stats'
     delegate_to: "{{ item }}"
     with_items: groups.lbservers
 
   - name: re-enable nagios alerts
-    nagios: action=enable_alerts host={{ inventory_hostname }} services=webserver
+    nagios: 'action=enable_alerts host={{ inventory_hostname }} services=webserver'
     delegate_to: "{{ item }}"
     with_items: groups.monitoring


### PR DESCRIPTION
The current `rolling_update.yml` example uses shell commands and `echo` to both remove and replace a backend server in HAProxy. Ansible 1.9 introduced the `haproxy` module, which does the same thing, but baked-in.

The example should be updated to use the official HAProxy module.

(This was discovered while writing a section in Ansible for DevOps on zero-downtime deployments with HAProxy as the load balancer).