### PR TITLE
Removing socat, example uses haproxy module

### DIFF
--- a/lamp_haproxy/roles/haproxy/tasks/main.yml
+++ b/lamp_haproxy/roles/haproxy/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 # This role installs HAProxy and configures it.
 
-- name: Download and install haproxy and socat
+- name: Download and install haproxy
   yum: name={{ item }} state=present
   with_items:
   - haproxy
-  - socat
 
 - name: Configure the haproxy cnf file with hosts
   template: src=haproxy.cfg.j2 dest=/etc/haproxy/haproxy.cfg

--- a/lamp_haproxy/roles/haproxy/tasks/main.yml
+++ b/lamp_haproxy/roles/haproxy/tasks/main.yml
@@ -2,9 +2,7 @@
 # This role installs HAProxy and configures it.
 
 - name: Download and install haproxy
-  yum: name={{ item }} state=present
-  with_items:
-  - haproxy
+  yum: name=haproxy state=present
 
 - name: Configure the haproxy cnf file with hosts
   template: src=haproxy.cfg.j2 dest=/etc/haproxy/haproxy.cfg


### PR DESCRIPTION
Previously socat (via shell) was used to enable/disable web servers in the loadbalancer pool.
This has now been replaced by http://docs.ansible.com/ansible/haproxy_module.html