### PR TITLE
Clean up an incorrect name.

### DIFF
--- a/lamp_haproxy/roles/base-apache/tasks/main.yml
+++ b/lamp_haproxy/roles/base-apache/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # This role installs httpd
 
-- name: Install http and php etc
+- name: Install http
   yum: name={{ item }} state=present
   with_items:
    - httpd


### PR DESCRIPTION
The base-apache tasks don't actually install php.
php is installed later, in the web role.

As such, I'd like to clean up the 'name'