### PR TITLE
Include md5 auth for local connections and task to verify Postgres is always running

### DIFF
--- a/language_features/postgresql.yml
+++ b/language_features/postgresql.yml
@@ -3,7 +3,9 @@
 #
 # This installs PostgreSQL on an Ubuntu system, creates a database called
 # "myapp" and a user called "django" with password "mysupersecretpassword"
-# with access to the "myapp" database.
+# with access to the "myapp" database. A provision for md5 authentication
+# for local connections is added and a task to verify that your Postgres is
+# always running.
 #
 ---
 - hosts: webservers
@@ -30,10 +32,6 @@
     dbuser: django
     dbpassword: mysupersecretpassword
 
-  handlers:
-  - name: Start postgresql
-  service: name=postgresql state=restarted enabled=yes
-
   tasks:
   - name: Ensure the PostgreSQL service is running
     service: name=postgresql state=started enabled=yes
@@ -53,3 +51,8 @@
 
   - name: ensure user does not have unnecessary privilege
     postgresql_user: name={{dbuser}} role_attr_flags=NOSUPERUSER,NOCREATEDB
+
+  handlers:
+  - name: Start postgresql
+  service: name=postgresql state=restarted enabled=yes
+

--- a/language_features/postgresql.yml
+++ b/language_features/postgresql.yml
@@ -30,7 +30,21 @@
     dbuser: django
     dbpassword: mysupersecretpassword
 
+  handlers:
+  - name: Start postgresql
+  service: name=postgresql state=restarted enabled=yes
+
   tasks:
+  - name: Ensure the PostgreSQL service is running
+    service: name=postgresql state=started enabled=yes
+
+  - name: Allow md5 authentication for local connections
+    lineinfile: >
+        dest='/etc/postgresql/9.3/main/pg_hba.conf'
+        regexp='^local.+all.+all.+peer$' backrefs=yes
+        line='local all all md5'
+    tags: packages
+
   - name: ensure database is created
     postgresql_db: name={{dbname}}
 


### PR DESCRIPTION
Include md5 auth for local connections and task to verify Postgres is always running.