### PR TITLE
Update playbook for RabbitMQ

### DIFF
--- a/language_features/rabbitmq.yml
+++ b/language_features/rabbitmq.yml
@@ -1,8 +1,6 @@
 ---
 - hosts: rabbitmq
-  sudo: true
-  vars:
-    rabbitmq_version: 3.0.2-1
+  become: true
 
   tasks:
   - name: ensure python-software-properties is installed
@@ -11,8 +9,13 @@
   - name: add rabbitmq official apt repository
     apt_repository: repo='deb http://www.rabbitmq.com/debian/ testing main' state=present
 
-  - name: install rabbitmq
-    apt: pkg=rabbitmq-server={{rabbitmq_version}} state=installed force=yes
+  - name: add trusted key
+    apt_key: url=https://www.rabbitmq.com/rabbitmq-signing-key-public.asc state=present
+
+  - name: install package
+    apt: name={{ item }} update_cache=yes state=installed
+    with_items:
+      - rabbitmq-server
 
   - name: enable rabbitmq plugins
     rabbitmq_plugin: names=rabbitmq_management,rabbitmq_tracing,rabbitmq_federation state=enabled
@@ -30,9 +33,6 @@
 
   - name: ensure vhost /test is present
     rabbitmq_vhost: name=/test state=present
-
-  - name: set federation local-username
-    rabbitmq_parameter: component=federation name=local-username value='"user1"' state=present
 
   handlers:
   - name: restart rabbitmq


### PR DESCRIPTION
- sudo: true is deprecated
- version is useless because official RabbitMQ repository install actual version of message broker
- is neccessary add trusted key
- set federation doesn't work for that I remove it

I tested it with Ansible 2.0.0.2.
