### PR TITLE
Install and start firewalld

### DIFF
--- a/wordpress-nginx_rhel7/roles/common/tasks/main.yml
+++ b/wordpress-nginx_rhel7/roles/common/tasks/main.yml
@@ -16,3 +16,9 @@
 
 - name: Create the GPG key for REMI
   copy: src=RPM-GPG-KEY-remi dest=/etc/pki/rpm-gpg
+  
+- name: Install Firewalld
+  yum: name=firewalld state=present
+
+- name: Firewalld service state
+  service: name=firewalld state=started enabled=yes


### PR DESCRIPTION
By default firewalld is not installed (CentOS Cloud image), the playbook drops this error, this patch aims to fix the issue :

TASK: [mariadb | insert firewalld rule] ***************************************
failed: [localhost] => {"failed": true, "parsed": false}
failed=True msg='firewalld required for this module'
OpenSSH_6.6.1, OpenSSL 1.0.1e-fips 11 Feb 2013
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: /etc/ssh/ssh_config line 56: Applying options for *
debug1: auto-mux: Trying existing master
debug1: mux_client_request_session: master session id: 2
Shared connection to localhost closed.


FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/root/site.retry

localhost                  : ok=10   changed=9    unreachable=0    failed=1