### PR TITLE
Fixes (#145) missing package + package install order

### DIFF
--- a/lamp_simple_rhel7/roles/common/tasks/main.yml
+++ b/lamp_simple_rhel7/roles/common/tasks/main.yml
@@ -5,6 +5,13 @@
   yum: name=ntp state=present
   tags: ntp
 
+- name: Install common dependencies
+  yum: name={{ item }} state=installed
+  with_items:
+   - libselinux-python
+   - libsemanage-python
+   - firewalld
+
 - name: Configure ntp file
   template: src=ntp.conf.j2 dest=/etc/ntp.conf
   tags: ntp

--- a/lamp_simple_rhel7/roles/db/tasks/main.yml
+++ b/lamp_simple_rhel7/roles/db/tasks/main.yml
@@ -6,8 +6,6 @@
   with_items:
    - mariadb-server
    - MySQL-python
-   - libselinux-python
-   - libsemanage-python
 
 - name: Configure SELinux to start mysql on any port
   seboolean: name=mysql_connect_any state=true persistent=yes
@@ -25,6 +23,9 @@
 
 - name: Start MariaDB Service
   service: name=mariadb state=started enabled=yes
+
+- name: Start firewalld
+  service: name=firewalld state=started enabled=yes
 
 - name: insert firewalld rule
   firewalld: port={{ mysql_port }}/tcp permanent=true state=enabled immediate=yes

--- a/lamp_simple_rhel7/roles/web/tasks/install_httpd.yml
+++ b/lamp_simple_rhel7/roles/web/tasks/install_httpd.yml
@@ -1,15 +1,20 @@
 ---
 # These tasks install http and the php modules.
 
-- name: Install http and php etc
+- name: Install httpd and php
   yum: name={{ item }} state=present
   with_items:
    - httpd
    - php
    - php-mysql
+
+- name: Install web role specific dependencies
+  yum: name={{ item }} state=installed
+  with_items:
    - git
-   - libsemanage-python
-   - libselinux-python
+
+- name: Start firewalld
+  service: name=firewalld state=started enabled=yes
 
 - name: insert firewalld rule for httpd
   firewalld: port={{ httpd_port }}/tcp permanent=true state=enabled immediate=yes


### PR DESCRIPTION
- firewalld is missing on a minimal CentOS7 install
- libselinux-python is needed before "Configure ntp file" in common task