### PR TITLE
revoke PUBLIC access from database

### DIFF
--- a/language_features/postgresql.yml
+++ b/language_features/postgresql.yml
@@ -39,3 +39,7 @@
 
   - name: ensure user does not have unnecessary privilege
     postgresql_user: name={{dbuser}} role_attr_flags=NOSUPERUSER,NOCREATEDB
+  
+  - name: ensure no other user can access the database
+    postgresql_privs: db={{dbname}} role=PUBLIC type=database priv=ALL state=absent
+


### PR DESCRIPTION
I edited this change by hand from a working local playbook. Verification welcome.

To clarify: without this change, every user on that postgres instance will have access to your database, instead of just the single user you specified.