### PR TITLE
Fixed wrong task names in mongodb example

### DIFF
--- a/mongodb/roles/mongod/tasks/main.yml
+++ b/mongodb/roles/mongod/tasks/main.yml
@@ -6,10 +6,10 @@
   delegate_to: '{{ item }}'
   with_items: groups.replication_servers
 
-- name: create data directory for mongodb
+- name: create log directory for mongodb
   file: path=/var/log/mongo state=directory owner=mongod group=mongod
 
-- name: create data directory for mongodb
+- name: create run directory for mongodb
   file: path=/var/run/mongo state=directory owner=mongod group=mongod
 
 - name: Create the mongodb startup file


### PR DESCRIPTION
Hi,

I've fixed some task names in the mongodb example - looks like someone duplicated a section and forgot to edit the task names.

Regards,
Johanan