### PR TITLE
Update WP version to 4.6, make firewalld rules non-fatal

### DIFF
--- a/wordpress-nginx_rhel7/group_vars/all
+++ b/wordpress-nginx_rhel7/group_vars/all
@@ -1,7 +1,7 @@
 ---
 # Variables listed here are applicable to all host groups
-wp_version: 4.3
-wp_sha256sum: 3b0db3abe8504f15a33cf64188a493ec0de01eaa8d20e37c3d6a1d9fa0a40fb4
+wp_version: 4.6
+wp_sha256sum: c1856cf969b1e73025ba2c681491908c3a4a6c5a2333f4531bf9bfb90f634380
 
 # MySQL settings
 mysqlservice: mysqld

--- a/wordpress-nginx_rhel7/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel7/roles/mariadb/tasks/main.yml
@@ -25,3 +25,4 @@
 
 - name: insert firewalld rule
   firewalld: port={{ mysql_port }}/tcp permanent=true state=enabled immediate=yes
+  ignore_errors: yes

--- a/wordpress-nginx_rhel7/roles/nginx/tasks/main.yml
+++ b/wordpress-nginx_rhel7/roles/nginx/tasks/main.yml
@@ -8,6 +8,7 @@
 
 - name: insert firewalld rule for nginx
   firewalld: port={{ nginx_port }}/tcp permanent=true state=enabled immediate=yes
+  ignore_errors: yes
 
 - name: http service state
   service: name=nginx state=started enabled=yes


### PR DESCRIPTION
- Update WP version and sha256 checksum to 4.6
- Make firewalld rules non-fatal, iptables-services is still
  a valid way to manage firewall rules or firewalld may be
  masked.
