### PR TITLE
Modified line break character from MS-DOS type into Linux type

### DIFF
--- a/tomcat-standalone/roles/tomcat/files/tomcat-initscript.sh
+++ b/tomcat-standalone/roles/tomcat/files/tomcat-initscript.sh
@@ -12,6 +12,9 @@
 # Added usage of CATALINA_BASE
 # Added coloring and additional status
 # Added check for existence of the tomcat user
+
+# Waynec updates (12, Sep.,2016):
+# Modify line break character from MS-DOS type into Linux type
 #
  
 #Location of JAVA_HOME (bin files)


### PR DESCRIPTION
The line break character in "tomcat-initscript.sh" are MS DOS type.
Somehow it will cause "TASK [tomcat : Start Tomcat]" failed.

Thus, I modified line break character in Linux type.