### PR TITLE
Added playbooks for flexible provisioning.

### DIFF
--- a/provisioning/aws/README.md
+++ b/provisioning/aws/README.md
@@ -1,0 +1,33 @@
+# AWS Provisioning Playbooks
+
+**Note**: these playbooks are not intended to serve as an example
+
+The following playbooks are designed to be general purpose provisioning
+playbooks. Keep in mind that these are not intended to serve as examples.
+They are used by the Ansible team in performing demonstrations.
+
+Here's an example of setting variables required by this provisioner:
+```yaml
+aws_region: us-east-1
+vpc_name: tcross-demo-vpc
+aws_instances:
+  - subnet_name: tcross-demo-vpc-public-subnet-a
+    keypair_name: tcross
+    ami_id: ami-b63769a1
+    type: t2.micro
+    tags:
+      Demo: provisioning
+  - subnet_name: tcross-demo-vpc-public-subnet-b
+    keypair_name: tcross
+    ami_id: ami-b63769a1
+    type: t2.micro
+    tags:
+      Demo: provisioning
+  - subnet_name: tcross-demo-vpc-public-subnet-c
+    keypair_name: tcross
+    ami_id: ami-b63769a1
+    type: t2.micro
+    tags:
+      Demo: provisioning
+
+```

--- a/provisioning/aws/all-deprovision.yml
+++ b/provisioning/aws/all-deprovision.yml
@@ -1,0 +1,12 @@
+---
+- name: Deprovision demo EC2 instances for the current user
+  hosts: tag_AnsibleDemo_True
+  gather_facts: no
+  become: no
+  tasks:
+    - name: Ensure demo EC2 instances are terminated
+      ec2:
+        region: "{{ aws_region }}"
+        instance_ids: "{{ ec2_id }}"
+        state: absent
+      delegate_to: localhost

--- a/provisioning/aws/provision.yml
+++ b/provisioning/aws/provision.yml
@@ -1,0 +1,92 @@
+---
+- name: Pre-Provisioning Setup
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  become: no
+  tasks:
+    - name: Check for required variables
+      fail:
+        msg: "Required variable not defined: {{ var_name }}"
+      when: item not in vars
+      with_items:
+        - aws_region
+        - vpc_name
+
+    - shell: whoami
+      register: whoami
+
+    - set_fact:
+        demo_user: "{{ whoami.stdout }}"
+
+    - set_fact:
+        demo_user: "{{ tower_user_name}}"
+      when: "{{ whoami.stdout == 'awx' }}"
+
+    - set_fact:
+        demo_tags:
+          Name: ansible-demo-{{ demo_user }}
+          AnsibleDemo: True
+          DemoUser: "{{ demo_user }}"
+
+    - name: Gather facts about the target VPC
+      ec2_vpc_net_facts:
+        aws_region: "{{ aws_region }}"
+        filters:
+          "tag:Name": "{{ vpc_name }}"
+      register: vpc_facts
+
+    - set_fact:
+        vpc_id: "{{ vpc_facts.vpcs[0].id }}"
+
+    - name: Create an inventory for provisioning purposes
+      add_host:
+        name: instance-{{ item.0 }}
+        aws_region: "{{ aws_region }}"
+        vpc_id: "{{ vpc_id }}"
+        subnet_name: "{{ item.1.subnet_name }}"
+        keypair_name: "{{ item.1.keypair_name }}"
+        tags: "{{ item.1.tags | combine(demo_tags) }}"
+        ami_id: "{{ item.1.ami_id }}"
+        type: "{{ item.1.instance_type | default('t2.micro')}}"
+      with_indexed_items: "{{ aws_instances | default([]) }}"
+
+- name: Provision EC2 instance
+  hosts: all
+  gather_facts: no
+  connection: local
+  tasks:
+    - name: Gather facts about the target subnet
+      ec2_vpc_subnet_facts:
+        aws_region: "{{ aws_region }}"
+        filters:
+          vpc-id: "{{ vpc_id }}"
+          "tag:Name": "{{ subnet_name }}"
+      register: target_subnet_facts
+
+    - set_fact:
+        subnet_id: "{{ target_subnet_facts.subnets[0].id }}"
+
+    - name: Create the EC2 instance
+      ec2:
+        aws_region: "{{ aws_region }}"
+        vpc_subnet_id: "{{ subnet_id }}"
+        key_name: "{{ keypair_name }}"
+        image: "{{ ami_id }}"
+        instance_type: "{{ type }}"
+        group: ansible-demo
+        assign_public_ip: yes
+        exact_count: 1
+        instance_tags: "{{ tags }}"
+        count_tag: "{{ tags }}"
+        wait: yes
+      async: 180
+      poll: 0
+      register: provisioning
+
+    - name: Check on provisioning
+      async_status:
+        jid: "{{ provisioning.ansible_job_id }}"
+      register: provisioning_result
+      until: "{{ provisioning_result.finished }}"
+      retries: 30

--- a/provisioning/aws/user-deprovision.yml
+++ b/provisioning/aws/user-deprovision.yml
@@ -1,0 +1,12 @@
+---
+- name: Deprovision demo EC2 instances for the current user
+  hosts: tag_AnsibleDemo_True:&tag_Name_ansible_demo_{{ demo_user }}
+  gather_facts: no
+  become: no
+  tasks:
+    - name: Ensure demo EC2 instances are terminated
+      ec2:
+        region: "{{ aws_region }}"
+        instance_ids: "{{ ec2_id }}"
+        state: absent
+      delegate_to: localhost


### PR DESCRIPTION
These are playbooks that will primarily be used for provisioning from Tower. The goal is to move away from needing the sandbox repo. This single playbook handles all provisioning cases for AWS. We'll need one similar for RHEV as well.