### PR TITLE
Add a version of wordpress-nginx for Debian/Ubuntu

### DIFF
--- a/wordpress-nginx_debian/LICENSE.md
+++ b/wordpress-nginx_debian/LICENSE.md
@@ -1,0 +1,4 @@
+Copyright (C) 2013 AnsibleWorks, Inc.
+
+This work is licensed under the Creative Commons Attribution 3.0 Unported License.
+To view a copy of this license, visit http://creativecommons.org/licenses/by/3.0/deed.en_US.

--- a/wordpress-nginx_debian/README.md
+++ b/wordpress-nginx_debian/README.md
@@ -1,0 +1,30 @@
+## WordPress+Nginx+PHP-FPM Deployment
+
+- Requires Ansible 1.2 or newer
+- Expects Debian 9 (Stretch) or Ubuntu 16.04 LTS or newer
+
+These playbooks deploy a simple all-in-one configuration of the popular
+WordPress blogging platform and CMS, frontend by the Nginx web server and the
+PHP-FPM process manager. To use, copy the `hosts.example` file to `hosts` and
+edit the `hosts` inventory file to include the names or URLs of the servers
+you want to deploy.
+
+Then run the playbook, like this:
+
+	ansible-playbook -i hosts site.yml
+
+The playbooks will configure WordPress, Nginx, PHP-FPM and MariaDB (or MySQL).
+When the run is complete, you can access your server to begin the WordPress
+configuration.
+
+### Ideas for Improvement
+
+Here are some ideas for ways that these playbooks could be extended:
+
+- Parameterize the WordPress deployment to handle multi-site configurations.
+- Separate the components (PHP-FPM, MariaDB, Nginx) onto separate hosts and
+handle the configuration appropriately.
+- Handle WordPress upgrades automatically.
+
+We would love to see contributions and improvements, so please fork this
+repository on GitHub and send us your changes via pull requests.

--- a/wordpress-nginx_debian/group_vars/all
+++ b/wordpress-nginx_debian/group_vars/all
@@ -1,0 +1,26 @@
+---
+# Which version of WordPress to deploy
+wp_version: 4.7
+wp_sha256sum: 7eae27ff70716dae2d2ba58280f2832fd70a208c9cdaf29ab36ac789c14d6977
+
+# These are the WordPress database settings
+wp_db_name: wordpress
+wp_db_user: wordpress
+wp_db_password: secret
+
+# This is used for the nginx server configuration, but access to the
+# WordPress site is not restricted by a named host.
+server_hostname: www.example.com
+
+# mariadb or mysql
+mysql_provider: mariadb
+
+# Disable All Updates
+# By default automatic updates are enabled, set this value to true to disable all automatic updates
+auto_up_disable: false
+
+#Define Core Update Level
+#true  = Development, minor, and major updates are all enabled
+#false = Development, minor, and major updates are all disabled
+#minor = Minor updates are enabled, development, and major updates are disabled
+core_update_level: true

--- a/wordpress-nginx_debian/hosts.example
+++ b/wordpress-nginx_debian/hosts.example
@@ -1,0 +1,2 @@
+[wordpress-server]
+webserver2

--- a/wordpress-nginx_debian/roles/common/tasks/main.yml
+++ b/wordpress-nginx_debian/roles/common/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Reload ansible_facts
+  setup:

--- a/wordpress-nginx_debian/roles/mysql/handlers/main.yml
+++ b/wordpress-nginx_debian/roles/mysql/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reload database
+  service: name=mysql state=reloaded

--- a/wordpress-nginx_debian/roles/mysql/tasks/main.yml
+++ b/wordpress-nginx_debian/roles/mysql/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Install {{ mysql_provider }}
+  apt: name={{ item }} state=present
+  with_items:
+   - "{{ mysql_provider }}-server"
+   - "{{ mysql_provider }}-client"
+   - python-mysqldb
+
+- name: Start {{ mysql_provider }}
+  service: name=mysql state=started enabled=yes

--- a/wordpress-nginx_debian/roles/nginx/handlers/main.yml
+++ b/wordpress-nginx_debian/roles/nginx/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart nginx
+  service: name=nginx state=restarted enabled=yes

--- a/wordpress-nginx_debian/roles/nginx/tasks/main.yml
+++ b/wordpress-nginx_debian/roles/nginx/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Install nginx
+  apt: name=nginx state=present
+  notify: restart nginx
+
+- name: Copy nginx configuration for WordPress
+  template: src=default dest=/etc/nginx/sites-available/default
+  notify: restart nginx

--- a/wordpress-nginx_debian/roles/nginx/templates/default
+++ b/wordpress-nginx_debian/roles/nginx/templates/default
@@ -1,0 +1,22 @@
+server {
+        listen       80 default_server;
+        server_name  {{ server_hostname }};
+        root /var/www/wordpress/ ;
+
+	client_max_body_size 64M;
+
+	# Deny access to any files with a .php extension in the uploads directory
+        location ~* /(?:uploads|files)/.*\.php$ {
+                deny all;
+        }
+
+        location / {
+                index index.php;
+                try_files $uri $uri/ /index.php?$args;
+        }
+
+        location ~ \.php$ {
+		include snippets/fastcgi-php.conf;
+		fastcgi_pass  unix:/run/php/php7.0-fpm.sock;
+        }
+}

--- a/wordpress-nginx_debian/roles/php-fpm/handlers/main.yml
+++ b/wordpress-nginx_debian/roles/php-fpm/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart php-fpm
+  service: name=php-fpm state=restarted

--- a/wordpress-nginx_debian/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx_debian/roles/php-fpm/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Install PHP dependencies
+  apt: name={{ item }} state=present
+  with_items:
+    - libphp-phpmailer
+    - php-bz2
+    - php-curl
+    - php-fpm
+    - php-getid3
+    - php-mbstring
+    - php-mysql
+    - php-xml
+    - php-zip
+    - unzip
+  notify: restart php-fpm

--- a/wordpress-nginx_debian/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx_debian/roles/wordpress/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Add group "wordpress"
+  group: name=wordpress
+
+- name: Add user "wordpress"
+  user: name=wordpress group=wordpress home=/var/www/wordpress/
+
+- name: Download WordPress
+  get_url: url=http://66.155.40.250/wordpress-{{ wp_version }}.tar.gz dest=/var/www/wordpress-{{ wp_version }}.tar.gz
+           sha256sum="{{ wp_sha256sum }}"
+
+- name: Extract WordPress
+  unarchive: src=/var/www/wordpress-{{ wp_version }}.tar.gz remote_src=True
+             dest=/var/www owner=wordpress group=wordpress
+
+- name: Create WordPress database
+  mysql_db: name={{ wp_db_name }} state=present
+
+- name: Create WordPress database user
+  mysql_user: name={{ wp_db_user }} password={{ wp_db_password }} priv={{ wp_db_name }}.*:ALL host='localhost' state=present
+
+- name: Fetch random salts for WordPress config
+  local_action: uri url=https://api.wordpress.org/secret-key/1.1/salt/ return_content=yes
+  register: "wp_salt"
+  become: no
+
+- name: Copy WordPress config file
+  template: src=wp-config.php dest=/var/www/wordpress/
+            owner=wordpress group=wordpress
+
+- name: Change ownership of WordPress installation
+  file: path=/var/www/wordpress/ owner=wordpress group=wordpress state=directory recurse=yes
+
+- name: Start php-fpm Service
+  service: name=php7.0-fpm state=started enabled=yes

--- a/wordpress-nginx_debian/roles/wordpress/templates/wp-config.php
+++ b/wordpress-nginx_debian/roles/wordpress/templates/wp-config.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * The base configurations of the WordPress.
+ *
+ * This file has the following configurations: MySQL settings, Table Prefix,
+ * Secret Keys, WordPress Language, and ABSPATH. You can find more information
+ * by visiting {@link http://codex.wordpress.org/Editing_wp-config.php Editing
+ * wp-config.php} Codex page. You can get the MySQL settings from your web host.
+ *
+ * This file is used by the wp-config.php creation script during the
+ * installation. You don't have to use the web site, you can just copy this file
+ * to "wp-config.php" and fill in the values.
+ *
+ * @package WordPress
+ */
+
+// ** MySQL settings - You can get this info from your web host ** //
+/** The name of the database for WordPress */
+define('DB_NAME', '{{ wp_db_name }}');
+
+/** MySQL database username */
+define('DB_USER', '{{ wp_db_user }}');
+
+/** MySQL database password */
+define('DB_PASSWORD', '{{ wp_db_password }}');
+
+/** MySQL hostname */
+define('DB_HOST', 'localhost');
+
+/** Database Charset to use in creating database tables. */
+define('DB_CHARSET', 'utf8');
+
+/** The Database Collate type. Don't change this if in doubt. */
+define('DB_COLLATE', '');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+
+{{ wp_salt.content }}
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each a unique
+ * prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix  = 'wp_';
+
+/**
+ * WordPress Localized Language, defaults to English.
+ *
+ * Change this to localize WordPress. A corresponding MO file for the chosen
+ * language must be installed to wp-content/languages. For example, install
+ * de_DE.mo to wp-content/languages and set WPLANG to 'de_DE' to enable German
+ * language support.
+ */
+define('WPLANG', '');
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ */
+define('WP_DEBUG', false);
+
+/** Disable Automatic Updates Completely */
+define( 'AUTOMATIC_UPDATER_DISABLED', {{auto_up_disable}} );
+
+/** Define AUTOMATIC Updates for Components. */
+define( 'WP_AUTO_UPDATE_CORE', {{core_update_level}} );
+
+/* That's all, stop editing! Happy blogging. */
+
+/** Absolute path to the WordPress directory. */
+if ( !defined('ABSPATH') )
+	define('ABSPATH', dirname(__FILE__) . '/');
+
+/** Sets up WordPress vars and included files. */
+require_once(ABSPATH . 'wp-settings.php');

--- a/wordpress-nginx_debian/site.yml
+++ b/wordpress-nginx_debian/site.yml
@@ -1,0 +1,12 @@
+---
+- name: Install WordPress, a database, nginx, and PHP-FPM
+  hosts: all
+  # remote_user: user
+  become: yes
+
+  roles:
+    - common
+    - mysql
+    - nginx
+    - php-fpm
+    - wordpress


### PR DESCRIPTION
I tested this with Ubuntu 16.04 and 16.10 and Debian Stretch ("testing", will be released as Debian 9 next year).

Maybe the only thing needed for earlier releases is changing the final `fastcgi_pass` line in `roles/nginx/templates/default`