### PR TITLE
Correct RabbitMQ Debian repo signing key

### DIFF
--- a/language_features/rabbitmq.yml
+++ b/language_features/rabbitmq.yml
@@ -13,7 +13,7 @@
     apt_repository: repo='deb http://www.rabbitmq.com/debian/ testing main' state=present
 
   - name: add trusted key
-    apt_key: url=https://www.rabbitmq.com/rabbitmq-signing-key-public.asc state=present
+    apt_key: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc state=present
 
   - name: install package
     apt: name={{ item }} update_cache=yes state=installed


### PR DESCRIPTION
See: https://www.rabbitmq.com/install-debian.html