### PR TITLE
Fix example to correctly reference "env" map variable

### DIFF
--- a/language_features/environment.yml
+++ b/language_features/environment.yml
@@ -25,9 +25,7 @@
       environment:
          HI: test1
 
-    # here we are using the $env variable above
+    # here we are using the "env" map variable above
 
     - shell: echo $HI
-      environment: env
-
-
+      environment: "{{ env }}"


### PR DESCRIPTION
This "works", but leaves me still confused.  YAML and Jinja says this is just a string, which I verified looks like a python dict. not surprisingly: 
    {u'http_proxy': u'http://proxy.example.com:8080', u'HI': u'test2'}

Since YAML like
    environment: "{{ env }}" 
should be setting 'environment' to a string, I assumed I could also do:

    - shell: echo $HI
       environment: "{u'foo':u'bar', u'HI':u'value'}"

But that fails with:
     [WARNING]: could not parse environment value, skipping: [u"{ u'foo': u'bar', u'HI': u'value' }"]

Which is really completely a digression, sorry.

