### PR TITLE
Don't install mod_php for php-fpm role

### DIFF
--- a/wordpress-nginx/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx/roles/php-fpm/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Install php-fpm and deps
   yum: name={{ item }} state=present
   with_items:
-    - php
     - php-fpm
     - php-enchant
     - php-IDNA_Convert

--- a/wordpress-nginx_rhel7/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx_rhel7/roles/php-fpm/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: Install php-fpm and deps
   yum: name={{ item }} state=present
   with_items:
-    - php
     - php-fpm
     - php-enchant
     - php-IDNA_Convert


### PR DESCRIPTION
The php package is mod_php, aka the Apache module for PHP.  It is unnecessary when using php-fpm.  The actual PHP language is in the php-common package, which is pulled in as a dependency of php-fpm.