### PR TITLE
The win_msi module has been deprecated

### DIFF
--- a/windows/install-msi.yml
+++ b/windows/install-msi.yml
@@ -9,7 +9,7 @@
         dest: 'C:\Users\Administrator\Downloads\httpd-2.2.25-win32-x86-no_ssl.msi'
 
     - name: Install MSI
-      win_msi: 
+      win_package: 
         path: 'C:\Users\Administrator\Downloads\httpd-2.2.25-win32-x86-no_ssl.msi'
         state: present
         


### PR DESCRIPTION
Removed in Ansible:
 	version: 2.8
Why:	The win_msi module has a number of issues, the win_package module is easier to maintain and use.
Alternative:	Use win_package instead.