### PR TITLE
Fix ansible-lint reported errors and update syntax in lamp_haproxy

### DIFF
--- a/lamp_haproxy/aws/roles/base-apache/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/base-apache/tasks/main.yml
@@ -2,16 +2,24 @@
 # This role installs httpd
 
 - name: Install http
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
    - httpd
    - php
    - php-mysql
    - git
-   
+
 - name: Configure SELinux to allow httpd to connect to remote database
-  seboolean: name=httpd_can_network_connect_db state=true persistent=yes
+  seboolean:
+    name: httpd_can_network_connect_db
+    state: true
+    persistent: yes
   when: sestatus.rc != 0
 
 - name: http service state
-  service: name=httpd state=started enabled=yes
+  service:
+    name: httpd
+    state: started
+    enabled: yes

--- a/lamp_haproxy/aws/roles/common/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/common/tasks/main.yml
@@ -2,19 +2,27 @@
 # This role contains common plays that will run on all nodes.
 
 - name: Install python bindings for SE Linux
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
    - libselinux-python
    - libsemanage-python
 
 - name: Create the repository for EPEL
-  copy: src=epel.repo dest=/etc/yum.repos.d/epel.repo
+  copy:
+    src: epel.repo
+    dest: /etc/yum.repos.d/epel.repo
 
 - name: Create the GPG key for EPEL
-  copy: src=RPM-GPG-KEY-EPEL-6 dest=/etc/pki/rpm-gpg
+  copy:
+    src: RPM-GPG-KEY-EPEL-6
+    dest: /etc/pki/rpm-gpg
 
 - name: install some useful nagios plugins
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
    - nagios-nrpe
    - nagios-plugins-swap
@@ -24,21 +32,30 @@
    - nagios-plugins-disk
 
 - name: Install ntp
-  yum: name=ntp state=present
+  yum:
+    name: ntp
+    state: present
   tags: ntp
 
 - name: Configure ntp file
-  template: src=ntp.conf.j2 dest=/etc/ntp.conf
+  template:
+    src: ntp.conf.j2
+    dest: /etc/ntp.conf
   tags: ntp
   notify: restart ntp
 
 - name: Start the ntp service
-  service: name=ntpd state=started enabled=yes
+  service:
+    name: ntpd
+    state: started
+    enabled: yes
   tags: ntp
 
 # work around RHEL 7, for now
 - name: insert iptables template
-  template: src=iptables.j2 dest=/etc/sysconfig/iptables
+  template:
+    src: iptables.j2
+    dest: /etc/sysconfig/iptables
   when: ansible_distribution_major_version != '7'
   notify: restart iptables
 

--- a/lamp_haproxy/aws/roles/db/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/db/tasks/main.yml
@@ -2,25 +2,42 @@
 # This role will install MySQL and create db user and give permissions.
 
 - name: Install Mysql package
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
    - mysql-server
    - MySQL-python
 
 - name: Configure SELinux to start mysql on any port
-  seboolean: name=mysql_connect_any state=true persistent=yes
+  seboolean:
+    name: mysql_connect_any
+    state: true
+    persistent: yes
   when: sestatus.rc != 0
 
 - name: Create Mysql configuration file
-  template: src=my.cnf.j2 dest=/etc/my.cnf
+  template:
+    src: my.cnf.j2
+    dest: /etc/my.cnf
   notify:
   - restart mysql
 
 - name: Start Mysql Service
-  service: name=mysqld state=started enabled=yes
+  service:
+    name: mysqld
+    state: started
+    enabled: yes
 
 - name: Create Application Database
-  mysql_db: name={{ dbname }} state=present
+  mysql_db:
+    name: "{{ dbname }}"
+    state: present
 
 - name: Create Application DB User
-  mysql_user: name={{ dbuser }} password={{ upassword }} priv=*.*:ALL host='%' state=present
+  mysql_user:
+    name: "{{ dbuser }}"
+    password: "{{ upassword }}"
+    priv: "*.*:ALL"
+    host: '%'
+    state: present

--- a/lamp_haproxy/aws/roles/haproxy/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/haproxy/tasks/main.yml
@@ -2,11 +2,18 @@
 # This role installs HAProxy and configures it.
 
 - name: Download and install haproxy
-  yum: name=haproxy state=present
+  yum:
+    nameL: haproxy
+    state: present
 
 - name: Configure the haproxy cnf file with hosts
-  template: src=haproxy.cfg.j2 dest=/etc/haproxy/haproxy.cfg
+  template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
   notify: restart haproxy
 
 - name: Start the haproxy service
-  service: name=haproxy state=started enabled=yes
+  service:
+    name: haproxy
+    state: started
+    enabled: yes

--- a/lamp_haproxy/aws/roles/nagios/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/nagios/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: create the nagios object files
   template:
-    src: "{{ item + .j2 }}"
+    src: "{{ item + '.j2' }}"
     dest: "/etc/nagios/ansible-managed/{{ item }}"
   with_items:
     - webservers.cfg

--- a/lamp_haproxy/aws/roles/nagios/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/nagios/tasks/main.yml
@@ -2,7 +2,9 @@
 # This will install nagios
 
 - name: install nagios
-  yum: pkg={{ item }} state=present
+  yum:
+    pkg: "{{ item }}"
+    state: present
   with_items:
    - nagios
    - nagios-plugins
@@ -15,22 +17,31 @@
   notify: restart httpd
 
 - name: create nagios config dir
-  file: path=/etc/nagios/ansible-managed state=directory
+  file:
+    path: /etc/nagios/ansible-managed
+    state: directory
 
 - name: configure nagios
-  copy: src=nagios.cfg dest=/etc/nagios/nagios.cfg
+  copy:
+    src: nagios.cfg
+    dest: /etc/nagios/nagios.cfg
   notify: restart nagios
 
 - name: configure localhost monitoring
-  copy: src=localhost.cfg dest=/etc/nagios/objects/localhost.cfg
+  copy:
+    src: localhost.cfg
+    dest: /etc/nagios/objects/localhost.cfg
   notify: restart nagios
 
 - name: configure nagios services
-  copy: src=ansible-managed-services.cfg dest=/etc/nagios/
+  copy:
+    src: ansible-managed-services.cfg
+    dest: /etc/nagios/
 
 - name: create the nagios object files
-  template: src={{ item + ".j2" }}
-            dest=/etc/nagios/ansible-managed/{{ item }}
+  template:
+    src: "{{ item + .j2 }}"
+    dest: "/etc/nagios/ansible-managed/{{ item }}"
   with_items:
     - webservers.cfg
     - dbservers.cfg

--- a/lamp_haproxy/aws/roles/web/tasks/main.yml
+++ b/lamp_haproxy/aws/roles/web/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: Copy the code from repository
-  git: repo={{ repository }} version={{ webapp_version }} dest=/var/www/html/
+  git:
+    repo: "{{ repository }}"
+    version: "{{ webapp_version }}"
+    dest: /var/www/html/

--- a/lamp_haproxy/aws/rolling_update.yml
+++ b/lamp_haproxy/aws/rolling_update.yml
@@ -19,12 +19,12 @@
   - name: disable nagios alerts for this host webserver service
     nagios: 'action=disable_alerts host={{ inventory_hostname }} services=webserver'
     delegate_to: "{{ item }}"
-    with_items: groups.tag_ansible_group_monitoring
+    with_items: "{{ groups.tag_ansible_group_monitoring }}"
 
   - name: disable the server in haproxy
     haproxy: 'state=disabled backend=myapplb host={{ inventory_hostname }} socket=/var/lib/haproxy/stats'
     delegate_to: "{{ item }}"
-    with_items: groups.tag_ansible_group_lbservers
+    with_items: "{{ groups.tag_ansible_group_lbservers }}"
 
   roles:
   - web
@@ -40,9 +40,9 @@
   - name: enable the server in haproxy
     haproxy: 'state=enabled backend=myapplb host={{ inventory_hostname }} socket=/var/lib/haproxy/stats'
     delegate_to: "{{ item }}"
-    with_items: groups.tag_ansible_group_lbservers
+    with_items: "{{ groups.tag_ansible_group_lbservers }}"
 
   - name: re-enable nagios alerts
     nagios: 'action=enable_alerts host={{ inventory_hostname }} services=webserver'
     delegate_to: "{{ item }}"
-    with_items: groups.tag_ansible_group_monitoring
+    with_items: "{{ groups.tag_ansible_group_monitoring }}"

--- a/lamp_haproxy/aws/site.yml
+++ b/lamp_haproxy/aws/site.yml
@@ -1,9 +1,9 @@
 ---
-## This playbook deploys the whole application stack in this site.  
+## This playbook deploys the whole application stack in this site.
 
 # Apply common configuration to all hosts
 - hosts: all
-  
+
   roles:
   - common
 
@@ -24,7 +24,7 @@
   roles:
   - base-apache
   - web
-  
+
   tags:
   - web
 
@@ -33,16 +33,16 @@
 
   roles:
   - haproxy
-  
+
   tags:
   - lb
 
 # Configure and deploy the Nagios monitoring node(s).
 - hosts: tag_ansible_group_monitoring
-  
+
   roles:
   - base-apache
   - nagios
-  
+
   tags:
   - monitoring

--- a/lamp_haproxy/roles/base-apache/tasks/main.yml
+++ b/lamp_haproxy/roles/base-apache/tasks/main.yml
@@ -2,16 +2,24 @@
 # This role installs httpd
 
 - name: Install http
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
    - httpd
    - php
    - php-mysql
    - git
-   
+
 - name: Configure SELinux to allow httpd to connect to remote database
-  seboolean: name=httpd_can_network_connect_db state=true persistent=yes
+  seboolean:
+    name: httpd_can_network_connect_db
+    state: true
+    persistent: yes
   when: sestatus.rc != 0
 
 - name: http service state
-  service: name=httpd state=started enabled=yes
+  service:
+    name: httpd
+    state: started
+    enabled: yes

--- a/lamp_haproxy/rolling_update.yml
+++ b/lamp_haproxy/rolling_update.yml
@@ -19,12 +19,12 @@
   - name: disable nagios alerts for this host webserver service
     nagios: 'action=disable_alerts host={{ inventory_hostname }} services=webserver'
     delegate_to: "{{ item }}"
-    with_items: groups.monitoring
+    with_items: "{{ groups.monitoring }}"
 
   - name: disable the server in haproxy
     haproxy: 'state=disabled backend=myapplb host={{ inventory_hostname }} socket=/var/lib/haproxy/stats'
     delegate_to: "{{ item }}"
-    with_items: groups.lbservers
+    with_items: "{{ groups.lbservers }}"
 
   roles:
   - common
@@ -39,9 +39,9 @@
   - name: enable the server in haproxy
     haproxy: 'state=enabled backend=myapplb host={{ inventory_hostname }} socket=/var/lib/haproxy/stats'
     delegate_to: "{{ item }}"
-    with_items: groups.lbservers
+    with_items: "{{ groups.lbservers }}"
 
   - name: re-enable nagios alerts
     nagios: 'action=enable_alerts host={{ inventory_hostname }} services=webserver'
     delegate_to: "{{ item }}"
-    with_items: groups.monitoring
+    with_items: "{{ groups.monitoring }}"

--- a/lamp_haproxy/site.yml
+++ b/lamp_haproxy/site.yml
@@ -1,9 +1,9 @@
 ---
-## This playbook deploys the whole application stack in this site.  
+## This playbook deploys the whole application stack in this site.
 
 # Apply common configuration to all hosts
 - hosts: all
-  
+
   roles:
   - common
 
@@ -24,7 +24,7 @@
   roles:
   - base-apache
   - web
-  
+
   tags:
   - web
 
@@ -33,16 +33,16 @@
 
   roles:
   - haproxy
-  
+
   tags:
   - lb
 
 # Configure and deploy the Nagios monitoring node(s).
 - hosts: monitoring
-  
+
   roles:
   - base-apache
   - nagios
-  
+
   tags:
   - monitoring


### PR DESCRIPTION
This PR cleans up the following with in the lamp_haproxy example directory:

Fix issues reported by ansible-lint
Update examples to use valid yaml syntax instead of older = syntax.
I am breaking these up as a PR per example so they can each be reviewed independently and any issues addressed individually.