### PR TITLE
Fix ansible-lint reported errors and update syntax in lamp_simple.

### DIFF
--- a/lamp_simple/roles/common/handlers/main.yml
+++ b/lamp_simple/roles/common/handlers/main.yml
@@ -3,4 +3,6 @@
 # See http://docs.ansible.com/playbooks_intro.html for more information about handlers.
 
 - name: restart ntp
-  service: name=ntpd state=restarted
+  service:
+    name: ntpd
+    state: restarted

--- a/lamp_simple/roles/common/tasks/main.yml
+++ b/lamp_simple/roles/common/tasks/main.yml
@@ -2,16 +2,23 @@
 # This playbook contains common plays that will be run on all nodes.
 
 - name: Install ntp
-  yum: name=ntp state=present
+  yum:
+    name: ntp
+    state: present
   tags: ntp
 
 - name: Configure ntp file
-  template: src=ntp.conf.j2 dest=/etc/ntp.conf
+  template:
+    src: ntp.conf.j2
+    dest: /etc/ntp.conf
   tags: ntp
   notify: restart ntp
 
 - name: Start the ntp service
-  service: name=ntpd state=started enabled=yes
+  service:
+    name: ntpd
+    state: started
+    enabled: yes
   tags: ntp
 
 - name: test to see if selinux is running

--- a/lamp_simple/roles/db/handlers/main.yml
+++ b/lamp_simple/roles/db/handlers/main.yml
@@ -2,7 +2,11 @@
 # Handler to handle DB tier notifications
 
 - name: restart mysql
-  service: name=mysqld state=restarted
+  service:
+    name: mysqld
+    state: restarted
 
 - name: restart iptables
-  service: name=iptables state=restarted
+  service:
+    name: iptables
+    state: restarted

--- a/lamp_simple/roles/db/tasks/main.yml
+++ b/lamp_simple/roles/db/tasks/main.yml
@@ -2,7 +2,9 @@
 # This playbook will install mysql and create db user and give permissions.
 
 - name: Install Mysql package
-  yum: name={{ item }} state=installed
+  yum:
+    name: "{{ item }}"
+    state: installed
   with_items:
    - mysql-server
    - MySQL-python
@@ -10,24 +12,43 @@
    - libsemanage-python
 
 - name: Configure SELinux to start mysql on any port
-  seboolean: name=mysql_connect_any state=true persistent=yes
+  seboolean:
+    name: mysql_connect_any
+    state: true
+    persistent: yes
   when: sestatus.rc != 0
 
 - name: Create Mysql configuration file
-  template: src=my.cnf.j2 dest=/etc/my.cnf
+  template:
+    src: my.cnf.j2
+    dest: /etc/my.cnf
   notify:
   - restart mysql
 
 - name: Start Mysql Service
-  service: name=mysqld state=started enabled=yes
+  service:
+    name: mysqld
+    state: started
+    enabled: yes
 
 - name: insert iptables rule
-  lineinfile: dest=/etc/sysconfig/iptables state=present regexp="{{ mysql_port }}"
-              insertafter="^:OUTPUT " line="-A INPUT -p tcp  --dport {{ mysql_port }} -j  ACCEPT"
+  lineinfile:
+    dest: /etc/sysconfig/iptables
+    state: present
+    regexp: "{{ mysql_port }}"
+    insertafter: "^:OUTPUT "
+    line: "-A INPUT -p tcp  --dport {{ mysql_port }} -j  ACCEPT"
   notify: restart iptables
 
 - name: Create Application Database
-  mysql_db: name={{ dbname }} state=present
+  mysql_db:
+    name: "{{ dbname }}"
+    state: present
 
 - name: Create Application DB User
-  mysql_user: name={{ dbuser }} password={{ upassword }} priv=*.*:ALL host='%' state=present
+  mysql_user:
+    name: "{{ dbuser }}"
+    password: "{{ upassword }}"
+    priv: "*.*:ALL"
+    host: '%'
+    state: present

--- a/lamp_simple/roles/web/handlers/main.yml
+++ b/lamp_simple/roles/web/handlers/main.yml
@@ -3,4 +3,6 @@
 # See http://docs.ansible.com/playbooks_intro.html for more information about handlers.
 
 - name: restart iptables
-  service: name=iptables state=restarted
+  service:
+    name: iptables
+    state: restarted

--- a/lamp_simple/roles/web/tasks/copy_code.yml
+++ b/lamp_simple/roles/web/tasks/copy_code.yml
@@ -3,7 +3,11 @@
 # the version control system.
 
 - name: Copy the code from repository
-  git: repo={{ repository }} dest=/var/www/html/
+  git:
+    repo: "{{ repository }}"
+    dest: /var/www/html/
 
 - name: Creates the index.php file
-  template: src=index.php.j2 dest=/var/www/html/index.php
+  template:
+    src: index.php.j2
+    dest: /var/www/html/index.php

--- a/lamp_simple/roles/web/tasks/install_httpd.yml
+++ b/lamp_simple/roles/web/tasks/install_httpd.yml
@@ -2,7 +2,9 @@
 # These tasks install http and the php modules.
 
 - name: Install http and php etc
-  yum: name={{ item }} state=present
+  yum:
+    name: "{{ item }}"
+    state: present
   with_items:
    - httpd
    - php
@@ -12,13 +14,24 @@
    - libselinux-python
 
 - name: insert iptables rule for httpd
-  lineinfile: dest=/etc/sysconfig/iptables create=yes state=present regexp="{{ httpd_port }}" insertafter="^:OUTPUT "
-              line="-A INPUT -p tcp  --dport {{ httpd_port }} -j  ACCEPT"
+  lineinfile:
+    dest: /etc/sysconfig/iptables
+    create: yes
+    state: present
+    regexp: "{{ httpd_port }}"
+    insertafter: "^:OUTPUT "
+    line: "-A INPUT -p tcp  --dport {{ httpd_port }} -j  ACCEPT"
   notify: restart iptables
 
 - name: http service state
-  service: name=httpd state=started enabled=yes
+  service:
+    name: httpd
+    state: started
+    enabled: yes
 
 - name: Configure SELinux to allow httpd to connect to remote database
-  seboolean: name=httpd_can_network_connect_db state=true persistent=yes
+  seboolean:
+    name: httpd_can_network_connect_db
+    state: true
+    persistent: yes
   when: sestatus.rc != 0


### PR DESCRIPTION
There is still one error reported by ansible-lint for the files in this directory:
```
 $ ansible-lint site.yml                                                                           
[ANSIBLE0004] Git checkouts must contain explicit version                                                                                                                     
/Users/jsmith39/src/external/jcsmith_ansible-examples/lamp_simple/roles/web/tasks/copy_code.yml:5
Task/Handler: Copy the code from repository
```
Specifying `version: head` to the git module did not seem to resolve the error so I'm not sure what to do about it and am open to suggestions.