### PR TITLE
Fix ansible-lintreported errors and update syntax in lamp_simple_rhel7.

### DIFF
--- a/lamp_simple_rhel7/roles/common/handlers/main.yml
+++ b/lamp_simple_rhel7/roles/common/handlers/main.yml
@@ -3,4 +3,6 @@
 # See http://docs.ansible.com/playbooks_intro.html for more information about handlers.
 
 - name: restart ntp
-  service: name=ntpd state=restarted
+  service:
+    name: ntpd
+    state: restarted

--- a/lamp_simple_rhel7/roles/common/tasks/main.yml
+++ b/lamp_simple_rhel7/roles/common/tasks/main.yml
@@ -2,21 +2,30 @@
 # This playbook contains common plays that will be run on all nodes.
 
 - name: Install ntp
-  yum: name=ntp state=present
+  yum:
+    name: ntp
+    state: present
   tags: ntp
 
 - name: Install common dependencies
-  yum: name={{ item }} state=installed
+  yum:
+    name: "{{ item }}"
+    state: "installed"
   with_items:
    - libselinux-python
    - libsemanage-python
    - firewalld
 
 - name: Configure ntp file
-  template: src=ntp.conf.j2 dest=/etc/ntp.conf
+  template:
+    src: ntp.conf.j2
+    dest: /etc/ntp.conf
   tags: ntp
   notify: restart ntp
 
 - name: Start the ntp service
-  service: name=ntpd state=started enabled=yes
+  service:
+    name: ntpd
+    state: started
+    enabled: yes
   tags: ntp

--- a/lamp_simple_rhel7/roles/db/handlers/main.yml
+++ b/lamp_simple_rhel7/roles/db/handlers/main.yml
@@ -2,4 +2,6 @@
 # Handler to handle DB tier notifications
 
 - name: restart mariadb
-  service: name=mariadb state=restarted
+  service:
+    name: mariadb
+    state: restarted

--- a/lamp_simple_rhel7/roles/db/tasks/main.yml
+++ b/lamp_simple_rhel7/roles/db/tasks/main.yml
@@ -2,36 +2,70 @@
 # This playbook will install MariaDB and create db user and give permissions.
 
 - name: Install MariaDB package
-  yum: name={{ item }} state=installed
+  yum:
+    name: "{{ item }}"
+    state: installed
   with_items:
    - mariadb-server
    - MySQL-python
 
 - name: Configure SELinux to start mysql on any port
-  seboolean: name=mysql_connect_any state=true persistent=yes
+  seboolean:
+    name: mysql_connect_any
+    state: true
+    persistent: yes
 
 - name: Create Mysql configuration file
-  template: src=my.cnf.j2 dest=/etc/my.cnf
+  template:
+    src: my.cnf.j2
+    dest: /etc/my.cnf
   notify:
   - restart mariadb
 
 - name: Create MariaDB log file
-  file: path=/var/log/mysqld.log state=touch owner=mysql group=mysql mode=0775
+  file:
+    path: /var/log/mysqld.log
+    state: touch
+    owner: mysql
+    group: mysql
+    mode: 0775
 
 - name: Create MariaDB PID directory
-  file: path=/var/run/mysqld state=directory owner=mysql group=mysql mode=0775
+  file:
+    path: /var/run/mysqld
+    state: directory
+    owner: mysql
+    group: mysql
+    mode: 0775
 
 - name: Start MariaDB Service
-  service: name=mariadb state=started enabled=yes
+  service:
+    name: mariadb
+    state: started
+    enabled: yes
 
 - name: Start firewalld
-  service: name=firewalld state=started enabled=yes
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
 
 - name: insert firewalld rule
-  firewalld: port={{ mysql_port }}/tcp permanent=true state=enabled immediate=yes
+  firewalld:
+    port: "{{ mysql_port }}/tcp"
+    permanent: true
+    state: enabled
+    immediate: yes
 
 - name: Create Application Database
-  mysql_db: name={{ dbname }} state=present
+  mysql_db:
+    name: "{{ dbname }}"
+    state: present
 
 - name: Create Application DB User
-  mysql_user: name={{ dbuser }} password={{ upassword }} priv=*.*:ALL host='%' state=present
+  mysql_user:
+    name: "{{ dbuser }}"
+    password: "{{ upassword }}"
+    priv: "*.*:ALL"
+    host: '%'
+    state: present

--- a/lamp_simple_rhel7/roles/web/tasks/copy_code.yml
+++ b/lamp_simple_rhel7/roles/web/tasks/copy_code.yml
@@ -3,7 +3,11 @@
 # the version control system.
 
 - name: Copy the code from repository
-  git: repo={{ repository }} dest=/var/www/html/
+  git:
+    repo: "{{ repository }}"
+    dest: /var/www/html/
 
 - name: Creates the index.php file
-  template: src=index.php.j2 dest=/var/www/html/index.php
+  template:
+    src: index.php.j2
+    dest: /var/www/html/index.php


### PR DESCRIPTION
There is still one error reported by ansible-lint for the files in this directory:
```
$ ansible-lint site.yml 
[ANSIBLE0004] Git checkouts must contain explicit version
/Users/jsmith39/src/external/jcsmith_ansible-examples/lamp_simple_rhel7/roles/web/tasks/copy_code.yml:5
Task/Handler: Copy the code from repository
```
Specifying version: head to the git module did not seem to resolve the error so I'm not sure what to do about it and am open to suggestions.