### PR TITLE
Fix ansible-lint errors in wordpress-nginx/site.yml

### DIFF
--- a/wordpress-nginx/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx/roles/wordpress/tasks/main.yml
@@ -4,7 +4,10 @@
            sha256sum="{{ wp_sha256sum }}"
 
 - name: Extract archive
-  command: chdir=/srv/ /bin/tar xvf wordpress-{{ wp_version }}.tar.gz creates=/srv/wordpress
+  unarchive:
+    creates: /srv/wordpress
+    src: /srv/wordpress-{{ wp_version }}.tar.gz
+    dest: /srv/wordpress
 
 - name: Add group "wordpress"
   group: name=wordpress

--- a/wordpress-nginx/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx/roles/wordpress/tasks/main.yml
@@ -20,6 +20,7 @@
   register: "wp_salt"
   become: no
   become_method: sudo
+  changed_when: false
 
 - name: Create WordPress database
   mysql_db: name={{ wp_db_name }} state=present

--- a/wordpress-nginx/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx/roles/wordpress/tasks/main.yml
@@ -22,6 +22,7 @@
   become: no
   become_method: sudo
   changed_when: true
+  delegate_to: localhost
 
 - name: Create WordPress database
   mysql_db: name={{ wp_db_name }} state=present

--- a/wordpress-nginx/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx/roles/wordpress/tasks/main.yml
@@ -21,7 +21,7 @@
   register: "wp_salt"
   become: no
   become_method: sudo
-  changed_when: false
+  changed_when: true
 
 - name: Create WordPress database
   mysql_db: name={{ wp_db_name }} state=present

--- a/wordpress-nginx/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx/roles/wordpress/tasks/main.yml
@@ -16,7 +16,8 @@
   user: name=wordpress group=wordpress home=/srv/wordpress/
 
 - name: Fetch random salts for WordPress config
-  local_action: command curl https://api.wordpress.org/secret-key/1.1/salt/
+  get_url:
+    url: https://api.wordpress.org/secret-key/1.1/salt/
   register: "wp_salt"
   become: no
   become_method: sudo


### PR DESCRIPTION
Fixing `ansible-lint` errors in `wordpress-nginx/site.yml` from https://github.com/ansible/ansible-examples/issues/271. With these changes:

```
$ ansible-lint wordpress-nginx/site.yml
<nothing>
```

Reference: https://docs.ansible.com/ansible-lint/rules/default_rules.html

_closes #271_