### PR TITLE
Updated WordPress and PHP versions, made SELinux policy tasks to be ignored if fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 wordpress-nginx/hosts
+wordpress-nginx_rhel7/site.retry
 .DS_Store

--- a/wordpress-nginx/roles/common/tasks/main.yml
+++ b/wordpress-nginx/roles/common/tasks/main.yml
@@ -6,11 +6,11 @@
   setup:
 
 - name: Copy the EPEL repository definition
-  copy: src=epel.repo dest=/etc/yum.repos.d/epel.repo
+  copy: src=epel.repo dest=/etc/yum.repos.d/epel.repo mode='0644'
 
 - name: Create the GPG key for EPEL
-  copy: src=RPM-GPG-KEY-EPEL-6 dest=/etc/pki/rpm-gpg
+  copy: src=RPM-GPG-KEY-EPEL-6 dest=/etc/pki/rpm-gpg mode='0644'
 
 - name: Set up iptables rules
-  copy: src=iptables-save dest=/etc/sysconfig/iptables
+  copy: src=iptables-save dest=/etc/sysconfig/iptables mode='0644'
   notify: restart iptables

--- a/wordpress-nginx/roles/mysql/tasks/main.yml
+++ b/wordpress-nginx/roles/mysql/tasks/main.yml
@@ -12,7 +12,7 @@
   when: ansible_selinux.status == "enabled"
 
 - name: Create Mysql configuration file
-  template: src=my.cnf.j2 dest=/etc/my.cnf
+  template: src=my.cnf.j2 dest=/etc/my.cnf mode='0644'
   notify:
   - restart mysql
 

--- a/wordpress-nginx/roles/nginx/tasks/main.yml
+++ b/wordpress-nginx/roles/nginx/tasks/main.yml
@@ -3,5 +3,5 @@
   yum: name=nginx state=present
 
 - name: Copy nginx configuration for wordpress
-  template: src=default.conf dest=/etc/nginx/conf.d/default.conf
+  template: src=default.conf dest=/etc/nginx/conf.d/default.conf mode='0644'
   notify: restart nginx

--- a/wordpress-nginx/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx/roles/php-fpm/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install php-fpm and deps
+- name: Install php_fpm and deps
   yum: name={{ item }} state=present
   with_items:
     - php

--- a/wordpress-nginx/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx/roles/php-fpm/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install php_fpm and deps
+- name: Install phpfpm and deps
   yum: name={{ item }} state=present
   with_items:
     - php

--- a/wordpress-nginx/roles/php-fpm/tasks/main.yml
+++ b/wordpress-nginx/roles/php-fpm/tasks/main.yml
@@ -18,5 +18,5 @@
   notify: restart php-fpm
 
 - name: Copy php-fpm configuration
-  template: src=wordpress.conf dest=/etc/php-fpm.d/
+  template: src=wordpress.conf dest=/etc/php-fpm.d/ mode='0644'
   notify: restart php-fpm

--- a/wordpress-nginx/roles/phpfpm/handlers/main.yml
+++ b/wordpress-nginx/roles/phpfpm/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart php-fpm
+  service: name=php-fpm state=restarted

--- a/wordpress-nginx/roles/phpfpm/tasks/main.yml
+++ b/wordpress-nginx/roles/phpfpm/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Install phpfpm and deps
+  yum: name={{ item }} state=present
+  with_items:
+    - php
+    - php-fpm
+    - php-enchant
+    - php-IDNA_Convert
+    - php-mbstring
+    - php-mysql
+    - php-PHPMailer
+    - php-process
+    - php-simplepie
+    - php-xml
+
+- name: Disable default pool
+  command: mv /etc/php-fpm.d/www.conf /etc/php-fpm.d/www.disabled creates=/etc/php-fpm.d/www.disabled
+  notify: restart php-fpm
+
+- name: Copy php-fpm configuration
+  template: src=wordpress.conf dest=/etc/php-fpm.d/ mode='0644'
+  notify: restart php-fpm

--- a/wordpress-nginx/roles/phpfpm/templates/wordpress.conf
+++ b/wordpress-nginx/roles/phpfpm/templates/wordpress.conf
@@ -1,0 +1,15 @@
+[wordpress]
+listen = /var/run/php-fpm/wordpress.sock
+listen.owner = nginx
+listen.group = nginx
+listen.mode = 0660
+user = wordpress
+group = wordpress
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 1
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+pm.max_requests = 500
+chdir = /srv/wordpress/
+php_admin_value[open_basedir] = /srv/wordpress/:/tmp

--- a/wordpress-nginx/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx/roles/wordpress/tasks/main.yml
@@ -8,6 +8,7 @@
     creates: /srv/wordpress
     src: /srv/wordpress-{{ wp_version }}.tar.gz
     dest: /srv/wordpress
+    mode: 0644
 
 - name: Add group "wordpress"
   group: name=wordpress
@@ -31,10 +32,10 @@
   mysql_user: name={{ wp_db_user }} password={{ wp_db_password }} priv={{ wp_db_name }}.*:ALL host='localhost' state=present
 
 - name: Copy WordPress config file
-  template: src=wp-config.php dest=/srv/wordpress/
+  template: src=wp-config.php dest=/srv/wordpress/ mode='0644'
 
 - name: Change ownership of WordPress installation
-  file: path=/srv/wordpress/ owner=wordpress group=wordpress state=directory recurse=yes setype=httpd_sys_content_t
+  file: path=/srv/wordpress/ owner=wordpress group=wordpress state=directory recurse=yes setype=httpd_sys_content_t mode='0644'
 
 - name: Start php-fpm Service
   service: name=php-fpm state=started enabled=yes

--- a/wordpress-nginx/site.yml
+++ b/wordpress-nginx/site.yml
@@ -10,5 +10,5 @@
     - common
     - mysql
     - nginx
-    - php-fpm
+    - phpfpm
     - wordpress

--- a/wordpress-nginx_rhel7/group_vars/all
+++ b/wordpress-nginx_rhel7/group_vars/all
@@ -1,7 +1,7 @@
 ---
 # Variables listed here are applicable to all host groups
-wp_version: 4.6
-wp_sha256sum: c1856cf969b1e73025ba2c681491908c3a4a6c5a2333f4531bf9bfb90f634380
+wp_version: 5.5.1
+wp_md5: 72c6f56b4818ffd0e6e6a4ed8f3e8d4e
 
 # MySQL settings
 mysqlservice: mysqld

--- a/wordpress-nginx_rhel7/roles/mariadb/tasks/main.yml
+++ b/wordpress-nginx_rhel7/roles/mariadb/tasks/main.yml
@@ -11,6 +11,7 @@
 
 - name: Configure SELinux to start mysql on any port
   seboolean: name=mysql_connect_any state=true persistent=yes
+  ignore_errors: yes
 
 - name: Create Mysql configuration file
   template: src=my.cnf.j2 dest=/etc/my.cnf

--- a/wordpress-nginx_rhel7/roles/nginx/templates/default.conf
+++ b/wordpress-nginx_rhel7/roles/nginx/templates/default.conf
@@ -23,7 +23,7 @@ server {
                 try_files $uri =404;
                 fastcgi_split_path_info ^(.+\.php)(/.+)$;
                 fastcgi_index index.php;
-                fastcgi_pass  unix:/var/run/php-fpm/wordpress.sock;
+                fastcgi_pass  unix:/var/opt/remi/php74/run/php-fpm/wordpress.sock;
                 fastcgi_param   SCRIPT_FILENAME
                                 $document_root$fastcgi_script_name;
                 include       fastcgi_params;

--- a/wordpress-nginx_rhel7/roles/php-fpm/handlers/main.yml
+++ b/wordpress-nginx_rhel7/roles/php-fpm/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart php-fpm
-  service: name=php-fpm state=restarted
+  service: name=php74-php-fpm state=restarted

--- a/wordpress-nginx_rhel7/roles/php-fpm/tasks/main.yml.bak
+++ b/wordpress-nginx_rhel7/roles/php-fpm/tasks/main.yml.bak
@@ -13,9 +13,9 @@
     - php74-php-xml
 
 - name: Disable default pool
-  command: mv /etc/opt/remi/php74/php-fpm.d/www.conf /etc/opt/remi/php74/php-fpm.d/www.disabled creates=/etc/opt/remi/php74/php-fpm.d/www.disabled
+  command: mv /etc/php-fpm.d/www.conf /etc/php-fpm.d/www.disabled creates=/etc/php-fpm.d/www.disabled
   notify: restart php-fpm
 
 - name: Copy php-fpm configuration
-  template: src=wordpress.conf dest=/etc/opt/remi/php74/php-fpm.d/
+  template: src=wordpress.conf dest=/etc/php-fpm.d/
   notify: restart php-fpm

--- a/wordpress-nginx_rhel7/roles/php-fpm/templates/wordpress.conf
+++ b/wordpress-nginx_rhel7/roles/php-fpm/templates/wordpress.conf
@@ -1,5 +1,5 @@
 [wordpress]
-listen = /var/run/php-fpm/wordpress.sock
+listen = /var/opt/remi/php74/run/php-fpm/wordpress.sock
 listen.owner = nginx
 listen.group = nginx
 listen.mode = 0660

--- a/wordpress-nginx_rhel7/roles/wordpress/tasks/main.yml
+++ b/wordpress-nginx_rhel7/roles/wordpress/tasks/main.yml
@@ -1,10 +1,21 @@
 ---
 - name: Download WordPress
-  get_url: url=http://wordpress.org/wordpress-{{ wp_version }}.tar.gz dest=/srv/wordpress-{{ wp_version }}.tar.gz
-           sha256sum="{{ wp_sha256sum }}"
+  get_url:
+    url: http://wordpress.org/wordpress-{{ wp_version }}.tar.gz
+    dest: /srv/wordpress-{{ wp_version }}.tar.gz
+    checksum: "md5:{{ wp_md5 }}"
+
+#- name: Create destination directory
+#  file:
+#    path: /srv/wordpress
+#    state: directory
+#    mode: '0755'
 
 - name: Extract archive
-  command: chdir=/srv/ /bin/tar xvf wordpress-{{ wp_version }}.tar.gz creates=/srv/wordpress
+  unarchive:
+    src: /srv/wordpress-{{ wp_version }}.tar.gz
+    dest: /srv
+    remote_src: yes
 
 - name: Add group "wordpress"
   group: name=wordpress
@@ -13,9 +24,11 @@
   user: name=wordpress group=wordpress home=/srv/wordpress/
 
 - name: Fetch random salts for WordPress config
-  local_action: command curl https://api.wordpress.org/secret-key/1.1/salt/
-  register: "wp_salt"
-  become: no
+  uri:
+    url: https://api.wordpress.org/secret-key/1.1/salt/
+    return_content: yes
+    method: GET
+  register: wp_salt
 
 - name: Create WordPress database
   mysql_db: name={{ wp_db_name }} state=present
@@ -34,27 +47,35 @@
 
 - name: set the SELinux policy for the Wordpress directory
   command: semanage fcontext -a -t httpd_sys_content_t "/srv/wordpress(/.*)?"
+  ignore_errors: yes
 
 - name: set the SELinux policy for wp-config.php
   command: semanage fcontext -a -t httpd_sys_script_exec_t "/srv/wordpress/wp-config\.php"
+  ignore_errors: yes
 
 - name: set the SELinux policy for wp-content directory
   command: semanage fcontext -a -t httpd_sys_rw_content_t "/srv/wordpress/wp-content(/.*)?"
+  ignore_errors: yes
 
 - name: set the SELinux policy for the *.php files
   command: semanage fcontext -a -t httpd_sys_script_exec_t "/srv/wordpress/.*\.php"
+  ignore_errors: yes
 
 - name: set the SELinux policy for the Upgrade directory
   command: semanage fcontext -a -t httpd_sys_rw_content_t "/srv/wordpress/wp-content/upgrade(/.*)?"
+  ignore_errors: yes
 
 - name: set the SELinux policy for the Uploads directory
   command: semanage fcontext -a -t httpd_sys_rw_content_t "/srv/wordpress/wp-content/uploads(/.*)?"
+  ignore_errors: yes
 
 - name: set the SELinux policy for the wp-includes php files
   command: semanage fcontext -a -t httpd_sys_script_exec_t "/srv/wordpress/wp-includes/.*\.php"
+  ignore_errors: yes
 
 - name: set the SELinux on all the Files
   command: restorecon -Rv /srv/wordpress
+  ignore_errors: yes
 
 - name: Start php-fpm Service
-  service: name=php-fpm state=started enabled=yes
+  service: name=php74-php-fpm state=started enabled=yes

--- a/wordpress-nginx_rhel7/roles/wordpress/templates/wp-config.php
+++ b/wordpress-nginx_rhel7/roles/wordpress/templates/wp-config.php
@@ -43,7 +43,7 @@ define('DB_COLLATE', '');
  * @since 2.6.0
  */
 
-{{ wp_salt.stdout }}
+{{ wp_salt.content }}
 
 /**#@-*/
 

--- a/wordpress-nginx_rhel7/site.yml
+++ b/wordpress-nginx_rhel7/site.yml
@@ -6,8 +6,8 @@
   # sudo: yes
 
   roles:
-    - common
-    - mariadb
-    - nginx
+    - {role: common, tags: common}
+    - {role: mariadb, tags: mariadb}
+    - {role: nginx, tags: nginx}
     - {role: php-fpm, tags: php-fpm}
-    - wordpress
+    - {role: wordpress, tags: wordpress}

--- a/wordpress-nginx_rhel7/site.yml
+++ b/wordpress-nginx_rhel7/site.yml
@@ -6,8 +6,8 @@
   # sudo: yes
 
   roles:
-    - {role: common, tags: common}
-    - {role: mariadb, tags: mariadb}
-    - {role: nginx, tags: nginx}
-    - {role: php-fpm, tags: php-fpm}
-    - {role: wordpress, tags: wordpress}
+    - common
+    - mariadb
+    - nginx
+    - php-fpm
+    - wordpress

--- a/wordpress-nginx_rhel7/site.yml
+++ b/wordpress-nginx_rhel7/site.yml
@@ -9,5 +9,5 @@
     - common
     - mariadb
     - nginx
-    - php-fpm
+    - {role: php-fpm, tags: php-fpm}
     - wordpress


### PR DESCRIPTION
Updated WordPress and PHP versions in the Ansible Playbook roles
Updated the SELinux related tasks to be ignored if failing (if SELinux is disabled for example, as it is on default CentOS7 installation)
Updated some Ansible tasks, which thrown warnings